### PR TITLE
fix(babel): replace outdated babel plugin

### DIFF
--- a/packages/babel/index.js
+++ b/packages/babel/index.js
@@ -118,7 +118,7 @@ const createBabelPresets = ({
       plugins: [
         require.resolve('@babel/plugin-transform-react-constant-elements'),
         require.resolve('@babel/plugin-transform-react-inline-elements'),
-        require.resolve('babel-plugin-transform-react-pure-class-to-function'),
+        require.resolve('babel-plugin-transform-react-class-to-function'),
         require.resolve('babel-plugin-transform-react-remove-prop-types')
       ]
     });

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -46,7 +46,7 @@
     "@loadable/babel-plugin": "5.13.2",
     "babel-plugin-import": "1.13.3",
     "babel-plugin-parameter-decorator": "1.0.16",
-    "babel-plugin-transform-react-pure-class-to-function": "1.0.1",
+    "babel-plugin-transform-react-class-to-function": "1.2.2",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "babel-plugin-transform-typescript-metadata": "0.3.2",
     "deepmerge": "4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7193,11 +7193,6 @@ babel-helper-is-nodes-equiv@^0.0.1:
   resolved "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz"
   integrity sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=
 
-babel-helper-is-react-class@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/babel-helper-is-react-class/-/babel-helper-is-react-class-1.0.0.tgz"
-  integrity sha1-7282eLBcdtve7a3q16+YwnJNhDE=
-
 babel-helper-is-void-0@^0.4.3:
   version "0.4.3"
   resolved "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz"
@@ -7774,12 +7769,12 @@ babel-plugin-transform-property-literals@^6.9.4:
   dependencies:
     esutils "^2.0.2"
 
-babel-plugin-transform-react-pure-class-to-function@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/babel-plugin-transform-react-pure-class-to-function/-/babel-plugin-transform-react-pure-class-to-function-1.0.1.tgz"
-  integrity sha1-MqZJyX1lMlC0Gc/RSJMxsCkNnuQ=
+babel-plugin-transform-react-class-to-function@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-class-to-function/-/babel-plugin-transform-react-class-to-function-1.2.2.tgz#9846c176eb2432bd6b42d9ed9a7cbc979a571245"
+  integrity sha512-qkRxpJ5iq1CATblWivTRRHSWGjbRptT7YTcCHo2KCDegn8dNu6CSvhrWW17RieItH9AZ+G2GsaRY+RnL1umthQ==
   dependencies:
-    babel-helper-is-react-class "^1.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
 
 babel-plugin-transform-react-remove-prop-types@0.4.24:
   version "0.4.24"
@@ -12443,14 +12438,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-file-loader@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
 
 file-loader@^4.2.0:
   version "4.3.0"
@@ -25048,15 +25035,6 @@ url-join@4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz"
   integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
-
-url-loader@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz"
-  integrity sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==
-  dependencies:
-    loader-utils "^2.0.0"
-    mime-types "^2.1.27"
-    schema-utils "^3.0.0"
 
 url-loader@^2.0.1:
   version "2.3.0"


### PR DESCRIPTION
Babel plugin "babel-plugin-transform-react-pure-class-to-function" is outdated.  It has not been updated for about 6 years and has crashes when using class components when directly importing the Component class from the react package.
Example:
```
import React, { Component } from React
 
class TestComponent extends Component {}
```
This code will be crashed

```
import React from React
 
class TestComponent extends React.Component {}
```
This is only solution I found for this plugin

I replaced it by new plugin ([github link](https://github.com/remcohaszing/babel-plugin-transform-react-class-to-function)). The plugin has no the issue